### PR TITLE
[update] Color-coded display of output results.

### DIFF
--- a/src/DefinitionDocument/Console/DefinitionDocumentCommand.php
+++ b/src/DefinitionDocument/Console/DefinitionDocumentCommand.php
@@ -46,8 +46,7 @@ class DefinitionDocumentCommand extends BaseCreateCommand
                 'Other' => app()->make(Other::class, ['readSpreadSheet' => $readSpreadSheet]),
                 default => throw new LogicException('There were no matching conditions'),
             };
-            $creator->run($targetFileName);
-            $this->info('Completed: '.$readSpreadSheet['category_tag']);
+            $creator->setOutput($this->output)->run($targetFileName);
         }
     }
 

--- a/src/DefinitionDocument/Creators/Base.php
+++ b/src/DefinitionDocument/Creators/Base.php
@@ -9,9 +9,10 @@ use LogicException;
 use StepUpDream\SpreadSheetConverter\DefinitionDocument\Definitions\Attribute;
 use StepUpDream\SpreadSheetConverter\DefinitionDocument\Definitions\ParentAttribute;
 use StepUpDream\SpreadSheetConverter\DefinitionDocument\Supports\FileOperation;
+use StepUpDream\SpreadSheetConverter\DefinitionDocument\Supports\LineMessage;
 use StepUpDream\SpreadSheetConverter\SpreadSheetReader\Readers\SpreadSheetReader;
 
-abstract class Base
+abstract class Base extends LineMessage
 {
     /**
      * Template blade file to use.
@@ -249,10 +250,12 @@ abstract class Base
                 DIRECTORY_SEPARATOR.$fileName;
             $loadBladeFile = $this->loadBladeFile($this->useBladeFileName, $parentAttribute);
             if (! $this->fileOperation->shouldCreate($loadBladeFile, $this->definitionDirectoryPath, $fileName)) {
+                $this->write($targetPath, 'SKIP', 'green');
                 continue;
             }
 
             $this->fileOperation->createFile($loadBladeFile, $targetPath, true);
+            $this->write($targetPath, 'CREATE');
         }
     }
 

--- a/src/DefinitionDocument/Creators/Other.php
+++ b/src/DefinitionDocument/Creators/Other.php
@@ -57,9 +57,11 @@ class Other extends Base
                 $fileName;
             $loadBladeFile = $this->loadBladeFile($this->useBladeFileName, $parentAttribute);
             if (! $this->fileOperation->shouldCreate($loadBladeFile, $this->definitionDirectoryPath, $fileName)) {
+                $this->write($targetPath, 'SKIP', 'green');
                 continue;
             }
             $this->fileOperation->createFile($loadBladeFile, $targetPath, true);
+            $this->write($targetPath, 'CREATE');
         }
     }
 }

--- a/src/DefinitionDocument/Supports/LineMessage.php
+++ b/src/DefinitionDocument/Supports/LineMessage.php
@@ -16,11 +16,6 @@ abstract class LineMessage
     protected OutputStyle $output;
 
     /**
-     * @var int Top margin.
-     */
-    protected int $topMargin = 1;
-
-    /**
      * @var bool whether it is the first time to write.
      */
     protected bool $isFirstTime = true;

--- a/src/DefinitionDocument/Supports/LineMessage.php
+++ b/src/DefinitionDocument/Supports/LineMessage.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StepUpDream\SpreadSheetConverter\DefinitionDocument\Supports;
+
+use Illuminate\Console\OutputStyle;
+
+abstract class LineMessage
+{
+    /**
+     * The output style implementation.
+     *
+     * @var \Illuminate\Console\OutputStyle
+     */
+    protected OutputStyle $output;
+
+    /**
+     * @var int Top margin.
+     */
+    protected int $topMargin = 1;
+
+    /**
+     * @var bool whether it is the first time to write.
+     */
+    protected bool $isFirstTime = true;
+
+    /**
+     * Set the output implementation that should be used by the console.
+     *
+     * @param  \Illuminate\Console\OutputStyle  $output
+     * @return $this
+     */
+    public function setOutput(OutputStyle $output): static
+    {
+        $this->output = $output;
+
+        return $this;
+    }
+
+    /**
+     * Output console log.
+     *
+     * @param  string  $content
+     * @param  string  $bgColor
+     * @param  string  $fgColor
+     * @param  string  $title
+     * @return void
+     */
+    public function write(string $content, string $title, string $bgColor = 'blue', string $fgColor = 'white'): void
+    {
+        if ($this->isFirstTime) {
+            $this->isFirstTime = false;
+            $this->output->writeln(sprintf("\n <bg=%s;fg=%s> %s </> %s", $bgColor, $fgColor, $title, $content));
+        } else {
+            $this->output->writeln(sprintf(' <bg=%s;fg=%s> %s </> %s', $bgColor, $fgColor, $title, $content));
+        }
+    }
+}


### PR DESCRIPTION
In the output results, clearly split between those that skipped file generation and those that generated files.